### PR TITLE
[seesaw] Stabilize shared-I2C rotary/button reads and avoid encoder zero jumps

### DIFF
--- a/esphome/components/seesaw/seesaw.cpp
+++ b/esphome/components/seesaw/seesaw.cpp
@@ -78,7 +78,7 @@ void Seesaw::enable_encoder(uint8_t number) { this->write8_(SEESAW_ENCODER, SEES
 
 int32_t Seesaw::get_encoder_position(uint8_t number) {
   uint8_t buf[4];
-  if (this->readbuf_(SEESAW_ENCODER, SEESAW_ENCODER_POSITION + number, buf, 4) != i2c::ERROR_OK)
+  if (this->readbuf_(SEESAW_ENCODER, SEESAW_ENCODER_POSITION + number, buf, 4, 1) != i2c::ERROR_OK)
     return 0;
   int32_t value = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
   return -value;  // make clockwise positive

--- a/esphome/components/seesaw/seesaw.cpp
+++ b/esphome/components/seesaw/seesaw.cpp
@@ -78,7 +78,7 @@ void Seesaw::enable_encoder(uint8_t number) { this->write8_(SEESAW_ENCODER, SEES
 
 int32_t Seesaw::get_encoder_position(uint8_t number) {
   uint8_t buf[4];
-  if (this->readbuf_(SEESAW_ENCODER, SEESAW_ENCODER_POSITION + number, buf, 4, 1) != i2c::ERROR_OK)
+  if (this->readbuf_(SEESAW_ENCODER, SEESAW_ENCODER_POSITION + number, buf, 4, 1000) != i2c::ERROR_OK)
     return 0;
   int32_t value = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
   return -value;  // make clockwise positive
@@ -86,14 +86,14 @@ int32_t Seesaw::get_encoder_position(uint8_t number) {
 
 int16_t Seesaw::get_touch_value(uint8_t channel) {
   uint8_t buf[2];
-  if (this->readbuf_(SEESAW_TOUCH, SEESAW_TOUCH_CHANNEL_OFFSET + channel, buf, 2, 3) != i2c::ERROR_OK)
+  if (this->readbuf_(SEESAW_TOUCH, SEESAW_TOUCH_CHANNEL_OFFSET + channel, buf, 2, 3000) != i2c::ERROR_OK)
     return -1;
   return ((uint16_t) buf[0] << 8) | buf[1];
 }
 
 float Seesaw::get_temperature() {
   uint8_t buf[4];
-  if (this->readbuf_(SEESAW_STATUS, SEESAW_STATUS_TEMP, buf, 4, 1) != i2c::ERROR_OK)
+  if (this->readbuf_(SEESAW_STATUS, SEESAW_STATUS_TEMP, buf, 4, 1000) != i2c::ERROR_OK)
     return NAN;
   uint32_t value = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
   if (value == 0xffffffff) {
@@ -132,7 +132,7 @@ void Seesaw::set_gpio_interrupt(uint32_t pin, bool enabled) {
 
 uint16_t Seesaw::analog_read(uint8_t pin) {
   uint8_t buf[2];
-  i2c::ErrorCode err = this->readbuf_(SEESAW_ADC, SEESAW_ADC_CHANNEL_OFFSET + pin, buf, 2, 1);
+  i2c::ErrorCode err = this->readbuf_(SEESAW_ADC, SEESAW_ADC_CHANNEL_OFFSET + pin, buf, 2, 1000);
   if (err == i2c::ERROR_OK)
     return (buf[0] << 8) + buf[1];
   return 0xffff;
@@ -191,14 +191,13 @@ i2c::ErrorCode Seesaw::write32_(SeesawModule mod, uint8_t reg, uint32_t value) {
   return this->write(buf, 6);
 }
 
-i2c::ErrorCode Seesaw::readbuf_(SeesawModule mod, uint8_t reg, uint8_t *buf, uint8_t len, int wait) {
+i2c::ErrorCode Seesaw::readbuf_(SeesawModule mod, uint8_t reg, uint8_t *buf, uint8_t len, int wait_us) {
   uint8_t sendbuf[2] = {mod, reg};
   i2c::ErrorCode err = this->write(sendbuf, 2);
   if (err != i2c::ERROR_OK)
     return err;
-  delayMicroseconds(250);
-  if (wait)
-    delay(wait);
+  if (wait_us)
+    delayMicroseconds(wait_us);
   return this->read(buf, len);
 }
 

--- a/esphome/components/seesaw/seesaw.cpp
+++ b/esphome/components/seesaw/seesaw.cpp
@@ -76,12 +76,16 @@ void Seesaw::dump_config() {
 
 void Seesaw::enable_encoder(uint8_t number) { this->write8_(SEESAW_ENCODER, SEESAW_ENCODER_INTENSET + number, 0x01); }
 
-int32_t Seesaw::get_encoder_position(uint8_t number) {
+bool Seesaw::get_encoder_position(uint8_t number, int32_t *position) {
+  if (position == nullptr)
+    return false;
+
   uint8_t buf[4];
   if (this->readbuf_(SEESAW_ENCODER, SEESAW_ENCODER_POSITION + number, buf, 4, 1000) != i2c::ERROR_OK)
-    return 0;
+    return false;
   int32_t value = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
-  return -value;  // make clockwise positive
+  *position = -value;  // make clockwise positive
+  return true;
 }
 
 int16_t Seesaw::get_touch_value(uint8_t channel) {

--- a/esphome/components/seesaw/seesaw.cpp
+++ b/esphome/components/seesaw/seesaw.cpp
@@ -196,6 +196,7 @@ i2c::ErrorCode Seesaw::readbuf_(SeesawModule mod, uint8_t reg, uint8_t *buf, uin
   i2c::ErrorCode err = this->write(sendbuf, 2);
   if (err != i2c::ERROR_OK)
     return err;
+  delayMicroseconds(250);
   if (wait)
     delay(wait);
   return this->read(buf, len);

--- a/esphome/components/seesaw/seesaw.h
+++ b/esphome/components/seesaw/seesaw.h
@@ -93,7 +93,7 @@ class Seesaw : public i2c::I2CDevice, public Component {
   float get_setup_priority() const override;
 
   void enable_encoder(uint8_t number);
-  int32_t get_encoder_position(uint8_t number);
+  bool get_encoder_position(uint8_t number, int32_t *position);
   int16_t get_touch_value(uint8_t channel);
   float get_temperature();
   void set_pinmode(uint8_t pin, uint8_t mode);

--- a/esphome/components/seesaw/seesaw.h
+++ b/esphome/components/seesaw/seesaw.h
@@ -109,7 +109,7 @@ class Seesaw : public i2c::I2CDevice, public Component {
   i2c::ErrorCode write8_(SeesawModule mod, uint8_t reg, uint8_t value);
   i2c::ErrorCode write16_(SeesawModule mod, uint8_t reg, uint16_t value);
   i2c::ErrorCode write32_(SeesawModule mod, uint8_t reg, uint32_t value);
-  i2c::ErrorCode readbuf_(SeesawModule mod, uint8_t reg, uint8_t *buf, uint8_t len, int wait = 0);
+  i2c::ErrorCode readbuf_(SeesawModule mod, uint8_t reg, uint8_t *buf, uint8_t len, int wait_us = 250);
 
   uint8_t cpuid_;
   uint32_t version_;

--- a/esphome/components/seesaw/sensor/seesaw_encoder.cpp
+++ b/esphome/components/seesaw/sensor/seesaw_encoder.cpp
@@ -12,7 +12,9 @@ void SeesawEncoder::setup() {
 }
 
 void SeesawEncoder::loop() {
-  int32_t new_value = this->parent_->get_encoder_position(this->number_);
+  int32_t new_value;
+  if (!this->parent_->get_encoder_position(this->number_, &new_value))
+    return;
   if (new_value < this->min_value_)
     new_value = this->min_value_;
   if (new_value > this->max_value_)


### PR DESCRIPTION
# What does this implement/fix?

This fixes Seesaw rotary/button instability on shared I2C buses (observed with QT rotary encoder + SH1107 OLED), where behavior was erratic and encoder values could jump to `0` on transient read failures.

Implemented fixes:

1. **Common read-path settle delay**
- Apply delay in `readbuf_()` before read (write-register -> wait -> read), so all Seesaw reads benefit, not only encoder reads.
- Align default timing with Adafruit behavior (`250us`).

2. **Wait unit normalization**
- Convert `readbuf_` wait semantics to **microseconds**.
- Set default wait to `250`.
- Update explicit waits accordingly:
  - encoder: `1` -> `1000`
  - temperature: `1` -> `1000`
  - ADC: `1` -> `1000`
  - touch: `3` -> `3000`

3. **Prevent encoder false zero updates**
- Change encoder read API from `int32_t get_encoder_position(...)` to `bool get_encoder_position(..., int32_t *out)`.
- On read error, skip update instead of publishing `0`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/ssieb/esphome_components/issues/95
- related https://github.com/esphome/esphome/pull/13538

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing YAML/config option changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:
- No config changes required for this fix.
- Existing seesaw encoder/button configs continue to work.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under tests/ folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).